### PR TITLE
Set hand pan defaults and fix note preview

### DIFF
--- a/__tests__/hand-pan-defaults.test.js
+++ b/__tests__/hand-pan-defaults.test.js
@@ -1,0 +1,54 @@
+import HandPanWrapper from '../components/hand-pan-wrapper/hand-pan-wrapper.js';
+
+describe('HandPan Default Values', () => {
+    let wrapper;
+
+    beforeEach(() => {
+        wrapper = new HandPanWrapper();
+        document.body.appendChild(wrapper);
+    });
+
+    afterEach(() => {
+        if (wrapper && wrapper.parentNode) {
+            wrapper.parentNode.removeChild(wrapper);
+        }
+    });
+
+    test('should have correct default reverb values', () => {
+        expect(wrapper.audioEffects.reverb.decay).toBe(1.4);
+        expect(wrapper.audioEffects.reverb.wet).toBe(0.8);
+        expect(wrapper.audioEffects.reverb.preDelay).toBe(0.04);
+    });
+
+    test('should have correct default chorus values', () => {
+        expect(wrapper.audioEffects.chorus.frequency).toBe(3.5);
+        expect(wrapper.audioEffects.chorus.depth).toBe(0.35);
+        expect(wrapper.audioEffects.chorus.wet).toBe(0.7);
+    });
+
+    test('should have correct default delay values', () => {
+        expect(wrapper.audioEffects.delay.delayTime).toBe(0.175);
+        expect(wrapper.audioEffects.delay.feedback).toBe(0.2);
+        expect(wrapper.audioEffects.delay.wet).toBe(0.85);
+    });
+
+    test('should have correct default synth values', () => {
+        expect(wrapper.audioEffects.synth.attack).toBe(0.062);
+        expect(wrapper.audioEffects.synth.decay).toBe(0.26);
+        expect(wrapper.audioEffects.synth.sustain).toBe(0.7);
+        expect(wrapper.audioEffects.synth.release).toBe(0.3);
+    });
+
+    test('should reset to correct default values', () => {
+        // Change some values
+        wrapper.audioEffects.reverb.decay = 0.5;
+        wrapper.audioEffects.chorus.frequency = 1.0;
+        
+        // Reset
+        wrapper.resetEffects();
+        
+        // Check that they're back to defaults
+        expect(wrapper.audioEffects.reverb.decay).toBe(1.4);
+        expect(wrapper.audioEffects.chorus.frequency).toBe(3.5);
+    });
+});

--- a/components/hand-pan-wrapper/hand-pan-wrapper.js
+++ b/components/hand-pan-wrapper/hand-pan-wrapper.js
@@ -16,26 +16,26 @@ export default class HandPanWrapper extends HTMLElement {
         // Audio effect properties
         this.audioEffects = {
             reverb: {
-                decay: 0.8,
-                wet: 0.25,
-                preDelay: 0.02
+                decay: 1.4,
+                wet: 0.8,
+                preDelay: 0.04
             },
             chorus: {
-                frequency: 2.5,
+                frequency: 3.5,
                 delayTime: 2.5,
-                depth: 0.7,
-                wet: 0.2
+                depth: 0.35,
+                wet: 0.7
             },
             delay: {
-                delayTime: 0.125, // 15n in seconds
+                delayTime: 0.175, // 15n in seconds
                 feedback: 0.2,
-                wet: 0.15
+                wet: 0.85
             },
             synth: {
-                attack: 0.005,
-                decay: 0.1,
-                sustain: 0.3,
-                release: 0.6
+                attack: 0.062,
+                decay: 0.26,
+                sustain: 0.7,
+                release: 0.3
             }
         };
         
@@ -403,55 +403,61 @@ export default class HandPanWrapper extends HTMLElement {
 
     async playAudioPreview() {
         try {
-            if (!this.previewSynth && this.audioEnabled) {
-                const { default: Tone } = await import('https://unpkg.com/tone@14.7.77/build/Tone.js');
-                
-                // Create a simple synth for preview
-                this.previewSynth = new Tone.Synth({
-                    oscillator: {
-                        type: 'sine'
-                    },
-                    envelope: {
-                        attack: 0.005,
-                        decay: 0.1,
-                        sustain: 0.3,
-                        release: 0.6
-                    }
-                });
-                
-                // Apply current audio effects to the preview synth
-                if (this.audioEffects) {
-                    // Create effects chain
-                    const reverb = new Tone.Reverb({
-                        decay: this.audioEffects.reverb.decay,
-                        preDelay: this.audioEffects.reverb.preDelay
-                    });
-                    reverb.wet.value = this.audioEffects.reverb.wet;
-                    
-                    const chorus = new Tone.Chorus({
-                        frequency: this.audioEffects.chorus.frequency,
-                        delayTime: this.audioEffects.chorus.delayTime,
-                        depth: this.audioEffects.chorus.depth
-                    });
-                    chorus.wet.value = this.audioEffects.chorus.wet;
-                    
-                    const delay = new Tone.FeedbackDelay({
-                        delayTime: this.audioEffects.delay.delayTime,
-                        feedback: this.audioEffects.delay.feedback
-                    });
-                    delay.wet.value = this.audioEffects.delay.wet;
-                    
-                    // Connect the chain
-                    this.previewSynth.chain(reverb, chorus, delay, Tone.Destination);
-                } else {
-                    this.previewSynth.toDestination();
-                }
+            if (!this.audioEnabled) {
+                return;
+            }
+
+            const { default: Tone } = await import('https://unpkg.com/tone@14.7.77/build/Tone.js');
+            
+            // Always dispose and recreate the preview synth to get fresh effects
+            if (this.previewSynth) {
+                this.previewSynth.dispose();
+                this.previewSynth = null;
             }
             
-            // Play C4 note if synth is ready
-            if (this.previewSynth) {
-                this.previewSynth.triggerAttackRelease('C4', '8n');
+            // Create a simple synth for preview
+            this.previewSynth = new Tone.Synth({
+                oscillator: {
+                    type: 'sine'
+                },
+                envelope: {
+                    attack: this.audioEffects.synth.attack,
+                    decay: this.audioEffects.synth.decay,
+                    sustain: this.audioEffects.synth.sustain,
+                    release: this.audioEffects.synth.release
+                }
+            });
+            
+            // Apply current audio effects to the preview synth
+            if (this.audioEffects) {
+                // Create effects chain
+                const reverb = new Tone.Reverb({
+                    decay: this.audioEffects.reverb.decay,
+                    preDelay: this.audioEffects.reverb.preDelay
+                });
+                reverb.wet.value = this.audioEffects.reverb.wet;
+                
+                const chorus = new Tone.Chorus({
+                    frequency: this.audioEffects.chorus.frequency,
+                    delayTime: this.audioEffects.chorus.delayTime,
+                    depth: this.audioEffects.chorus.depth
+                });
+                chorus.wet.value = this.audioEffects.chorus.wet;
+                
+                const delay = new Tone.FeedbackDelay({
+                    delayTime: this.audioEffects.delay.delayTime,
+                    feedback: this.audioEffects.delay.feedback
+                });
+                delay.wet.value = this.audioEffects.delay.wet;
+                
+                // Connect the chain
+                this.previewSynth.chain(reverb, chorus, delay, Tone.Destination);
+            } else {
+                this.previewSynth.toDestination();
             }
+            
+            // Play C4 note
+            this.previewSynth.triggerAttackRelease('C4', '8n');
         } catch (error) {
             console.log('Audio preview error:', error);
         }
@@ -505,26 +511,26 @@ export default class HandPanWrapper extends HTMLElement {
         // Reset to default values
         this.audioEffects = {
             reverb: {
-                decay: 0.8,
-                wet: 0.25,
-                preDelay: 0.02
+                decay: 1.4,
+                wet: 0.8,
+                preDelay: 0.04
             },
             chorus: {
-                frequency: 2.5,
+                frequency: 3.5,
                 delayTime: 2.5,
-                depth: 0.7,
-                wet: 0.2
+                depth: 0.35,
+                wet: 0.7
             },
             delay: {
-                delayTime: 0.125,
+                delayTime: 0.175,
                 feedback: 0.2,
-                wet: 0.15
+                wet: 0.85
             },
             synth: {
-                attack: 0.005,
-                decay: 0.1,
-                sustain: 0.3,
-                release: 0.6
+                attack: 0.062,
+                decay: 0.26,
+                sustain: 0.7,
+                release: 0.3
             }
         };
 

--- a/components/hand-pan/hand-pan.js
+++ b/components/hand-pan/hand-pan.js
@@ -74,33 +74,33 @@ export default class HandPan extends HTMLElement {
                 type: "triangle"  // Base metallic sound
             },
             envelope: {
-                attack: 0.005,    // Very quick attack for immediate response
-                decay: 0.1,       // Quick decay to sustain level
-                sustain: 0.3,     // Lower sustain for faster fade
-                release: 0.6      // Faster release for quicker note fade
+                attack: 0.062,    // Slightly longer attack for smoother response
+                decay: 0.26,      // Longer decay for richer tone
+                sustain: 0.7,     // Higher sustain for longer notes
+                release: 0.3      // Shorter release for quicker note fade
             }
         });
 
         // Create enhanced reverb for steel drum resonance
         this.reverb = new Tone.Reverb({
-            decay: 0.8,           // Shorter decay for faster note fade
-            wet: 0.25,            // Less reverb for cleaner sound
-            preDelay: 0.02        // Very short pre-delay for quick response
+            decay: 1.4,           // Longer decay for richer resonance
+            wet: 0.8,             // More reverb for atmospheric sound
+            preDelay: 0.04        // Slightly longer pre-delay for depth
         });
 
         // Add chorus for steel drum shimmer
         this.chorus = new Tone.Chorus({
-            frequency: 2.5,
+            frequency: 3.5,
             delayTime: 2.5,
-            depth: 0.7,
-            wet: 0.2
+            depth: 0.35,
+            wet: 0.7
         });
 
         // Add subtle delay for steel drum echo
         this.delay = new Tone.PingPongDelay({
-            delayTime: 0.125,     // Convert from "15n" to seconds
+            delayTime: 0.175,     // Longer delay time for more echo
             feedback: 0.2,
-            wet: 0.15
+            wet: 0.85
         });
 
         // Create effects chain: synth → chorus → delay → reverb → destination

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -3229,20 +3229,6 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -3623,6 +3609,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3639,6 +3639,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",

--- a/test-default-values.html
+++ b/test-default-values.html
@@ -1,0 +1,281 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>HandPan Default Values Test</title>
+    <style>
+        body {
+            margin: 0;
+            padding: 20px;
+            background: linear-gradient(135deg, #0f0f23, #1a1a2e);
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            color: #fff;
+            min-height: 100vh;
+        }
+
+        .test-header {
+            text-align: center;
+            margin-bottom: 30px;
+        }
+
+        .test-header h1 {
+            font-size: 2.5em;
+            margin-bottom: 10px;
+            background: linear-gradient(45deg, #4CAF50, #2196F3);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+        }
+
+        .test-results {
+            background: rgba(255,255,255,0.1);
+            border-radius: 10px;
+            padding: 20px;
+            margin-bottom: 30px;
+            border: 1px solid rgba(255,255,255,0.2);
+        }
+
+        .test-results h2 {
+            margin-top: 0;
+            color: #4CAF50;
+        }
+
+        .test-item {
+            margin-bottom: 10px;
+            padding: 10px;
+            border-radius: 5px;
+            background: rgba(0,0,0,0.2);
+        }
+
+        .test-pass {
+            border-left: 4px solid #4CAF50;
+            color: #4CAF50;
+        }
+
+        .test-fail {
+            border-left: 4px solid #f44336;
+            color: #f44336;
+        }
+
+        .expected-values {
+            background: rgba(255,255,255,0.05);
+            border-radius: 10px;
+            padding: 20px;
+            margin-bottom: 30px;
+            border: 1px solid rgba(255,255,255,0.1);
+        }
+
+        .expected-values h2 {
+            margin-top: 0;
+            color: #FF9800;
+        }
+
+        .value-group {
+            margin-bottom: 15px;
+        }
+
+        .value-group h3 {
+            margin: 0 0 10px 0;
+            color: #2196F3;
+        }
+
+        .value-item {
+            display: flex;
+            justify-content: space-between;
+            margin-bottom: 5px;
+            padding: 5px;
+            background: rgba(0,0,0,0.2);
+            border-radius: 3px;
+        }
+    </style>
+</head>
+<body>
+    <div class="test-header">
+        <h1>🧪 HandPan Default Values Test</h1>
+        <p>Testing the new default values and note preview functionality</p>
+    </div>
+
+    <div class="expected-values">
+        <h2>📋 Expected Default Values</h2>
+        
+        <div class="value-group">
+            <h3>🌊 Reverb</h3>
+            <div class="value-item">
+                <span>Decay:</span>
+                <span>1.400</span>
+            </div>
+            <div class="value-item">
+                <span>Wet:</span>
+                <span>0.800</span>
+            </div>
+            <div class="value-item">
+                <span>Pre-delay:</span>
+                <span>0.040</span>
+            </div>
+        </div>
+
+        <div class="value-group">
+            <h3>🎭 Chorus</h3>
+            <div class="value-item">
+                <span>Frequency:</span>
+                <span>3.500</span>
+            </div>
+            <div class="value-item">
+                <span>Depth:</span>
+                <span>0.350</span>
+            </div>
+            <div class="value-item">
+                <span>Wet:</span>
+                <span>0.700</span>
+            </div>
+        </div>
+
+        <div class="value-group">
+            <h3>⏱️ Delay</h3>
+            <div class="value-item">
+                <span>Time:</span>
+                <span>0.175</span>
+            </div>
+            <div class="value-item">
+                <span>Feedback:</span>
+                <span>0.200</span>
+            </div>
+            <div class="value-item">
+                <span>Wet:</span>
+                <span>0.850</span>
+            </div>
+        </div>
+
+        <div class="value-group">
+            <h3>🎹 Synth</h3>
+            <div class="value-item">
+                <span>Attack:</span>
+                <span>0.062</span>
+            </div>
+            <div class="value-item">
+                <span>Decay:</span>
+                <span>0.260</span>
+            </div>
+            <div class="value-item">
+                <span>Sustain:</span>
+                <span>0.700</span>
+            </div>
+            <div class="value-item">
+                <span>Release:</span>
+                <span>0.300</span>
+            </div>
+        </div>
+    </div>
+
+    <!-- The HandPan Wrapper Component -->
+    <hand-pan-wrapper id="testHandPan"></hand-pan-wrapper>
+
+    <div class="test-results">
+        <h2>✅ Test Results</h2>
+        <div id="testResults">
+            <div class="test-item">Running tests...</div>
+        </div>
+    </div>
+
+    <!-- Load Tone.js -->
+    <script src="https://unpkg.com/tone@14.7.77/build/Tone.js"></script>
+    
+    <!-- Load our components -->
+    <script type="module">
+        import HandPanWrapper from './components/hand-pan-wrapper/hand-pan-wrapper.js';
+        
+        const wrapper = document.getElementById('testHandPan');
+        const testResults = document.getElementById('testResults');
+        
+        function addTestResult(testName, passed, actualValue = null, expectedValue = null) {
+            const testItem = document.createElement('div');
+            testItem.className = `test-item ${passed ? 'test-pass' : 'test-fail'}`;
+            
+            if (passed) {
+                testItem.innerHTML = `✅ ${testName}`;
+            } else {
+                testItem.innerHTML = `❌ ${testName} - Expected: ${expectedValue}, Got: ${actualValue}`;
+            }
+            
+            testResults.appendChild(testItem);
+        }
+
+        function runTests() {
+            testResults.innerHTML = '';
+            
+            // Test reverb defaults
+            addTestResult('Reverb Decay', 
+                Math.abs(wrapper.audioEffects.reverb.decay - 1.4) < 0.001, 
+                wrapper.audioEffects.reverb.decay, 1.4);
+            
+            addTestResult('Reverb Wet', 
+                Math.abs(wrapper.audioEffects.reverb.wet - 0.8) < 0.001, 
+                wrapper.audioEffects.reverb.wet, 0.8);
+            
+            addTestResult('Reverb Pre-delay', 
+                Math.abs(wrapper.audioEffects.reverb.preDelay - 0.04) < 0.001, 
+                wrapper.audioEffects.reverb.preDelay, 0.04);
+            
+            // Test chorus defaults
+            addTestResult('Chorus Frequency', 
+                Math.abs(wrapper.audioEffects.chorus.frequency - 3.5) < 0.001, 
+                wrapper.audioEffects.chorus.frequency, 3.5);
+            
+            addTestResult('Chorus Depth', 
+                Math.abs(wrapper.audioEffects.chorus.depth - 0.35) < 0.001, 
+                wrapper.audioEffects.chorus.depth, 0.35);
+            
+            addTestResult('Chorus Wet', 
+                Math.abs(wrapper.audioEffects.chorus.wet - 0.7) < 0.001, 
+                wrapper.audioEffects.chorus.wet, 0.7);
+            
+            // Test delay defaults
+            addTestResult('Delay Time', 
+                Math.abs(wrapper.audioEffects.delay.delayTime - 0.175) < 0.001, 
+                wrapper.audioEffects.delay.delayTime, 0.175);
+            
+            addTestResult('Delay Feedback', 
+                Math.abs(wrapper.audioEffects.delay.feedback - 0.2) < 0.001, 
+                wrapper.audioEffects.delay.feedback, 0.2);
+            
+            addTestResult('Delay Wet', 
+                Math.abs(wrapper.audioEffects.delay.wet - 0.85) < 0.001, 
+                wrapper.audioEffects.delay.wet, 0.85);
+            
+            // Test synth defaults
+            addTestResult('Synth Attack', 
+                Math.abs(wrapper.audioEffects.synth.attack - 0.062) < 0.001, 
+                wrapper.audioEffects.synth.attack, 0.062);
+            
+            addTestResult('Synth Decay', 
+                Math.abs(wrapper.audioEffects.synth.decay - 0.26) < 0.001, 
+                wrapper.audioEffects.synth.decay, 0.26);
+            
+            addTestResult('Synth Sustain', 
+                Math.abs(wrapper.audioEffects.synth.sustain - 0.7) < 0.001, 
+                wrapper.audioEffects.synth.sustain, 0.7);
+            
+            addTestResult('Synth Release', 
+                Math.abs(wrapper.audioEffects.synth.release - 0.3) < 0.001, 
+                wrapper.audioEffects.synth.release, 0.3);
+            
+            // Test reset functionality
+            wrapper.audioEffects.reverb.decay = 0.5;
+            wrapper.resetEffects();
+            addTestResult('Reset Effects', 
+                Math.abs(wrapper.audioEffects.reverb.decay - 1.4) < 0.001, 
+                wrapper.audioEffects.reverb.decay, 1.4);
+        }
+
+        // Run tests after component is loaded
+        setTimeout(runTests, 1000);
+        
+        // Test note preview functionality
+        setTimeout(() => {
+            addTestResult('Note Preview Toggle Available', 
+                wrapper.shadowRoot.getElementById('audioPreviewToggle') !== null);
+        }, 1500);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Update hand pan default effect values and fix the note preview functionality for a richer sound and improved user experience.

The note preview was not working because the preview synth was being disposed and recreated on every slider change, making it unavailable when `playAudioPreview()` was called. The fix ensures the synth is properly recreated with current effects and connected to the audio chain.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-e1b9e15f-1bd0-4c71-970d-6926496747a2) · [Cursor](https://cursor.com/background-agent?bcId=bc-e1b9e15f-1bd0-4c71-970d-6926496747a2)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)