### PR TITLE
Update /demos/ production redirects

### DIFF
--- a/_headers
+++ b/_headers
@@ -17,6 +17,38 @@
 /*.png
   Cache-Control: public, max-age=31536000, immutable
 
+/chord-library.js
+  Content-Type: application/javascript
+  Cache-Control: public, max-age=31536000, immutable
+
+/song-library.js
+  Content-Type: application/javascript
+  Cache-Control: public, max-age=31536000, immutable
+
+/components/*
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+
+/components/*.js
+  Content-Type: application/javascript
+  Cache-Control: public, max-age=31536000, immutable
+
+/helpers/*
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+
+/helpers/*.js
+  Content-Type: application/javascript
+  Cache-Control: public, max-age=31536000, immutable
+
+/state/*
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+
+/state/*.js
+  Content-Type: application/javascript
+  Cache-Control: public, max-age=31536000, immutable
+
 /demos/*
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff

--- a/_redirects
+++ b/_redirects
@@ -1,1 +1,5 @@
-/    /index.html   200 /demos/styles.css    /demos/styles/demo-main.css    200
+# Serve demo files directly without redirecting
+/demos/*    /demos/:splat    200
+
+# Serve the main index.html for the root
+/    /index.html    200

--- a/demos/add-chord-demo.html
+++ b/demos/add-chord-demo.html
@@ -131,7 +131,7 @@
     <!-- Component-specific script will be inserted here -->
     
     <script type="module">
-        import './components/add-chord/add-chord.js';
+        import '../components/add-chord/add-chord.js';
         
         document.addEventListener('DOMContentLoaded', function() {
             const component = document.getElementById('demo-component');

--- a/demos/chord-diagram-demo.html
+++ b/demos/chord-diagram-demo.html
@@ -131,7 +131,7 @@
     <!-- Component-specific script will be inserted here -->
     
     <script type="module">
-        import './components/chord-diagram/chord-diagram.js';
+        import '../components/chord-diagram/chord-diagram.js';
         
         document.addEventListener('DOMContentLoaded', function() {
             const component = document.getElementById('demo-component');

--- a/demos/chord-palette-demo.html
+++ b/demos/chord-palette-demo.html
@@ -152,7 +152,7 @@
     <!-- Component-specific script will be inserted here -->
     
     <script type="module">
-        import './components/chord-palette/chord-palette.js';
+        import '../components/chord-palette/chord-palette.js';
         
         document.addEventListener('DOMContentLoaded', function() {
             const component = document.getElementById('demo-component');

--- a/demos/chromatic-tuner-demo.html
+++ b/demos/chromatic-tuner-demo.html
@@ -131,7 +131,7 @@
     <!-- Component-specific script will be inserted here -->
     
     <script type="module">
-        import './components/chromatic-tuner/chromatic-tuner.js';
+        import '../components/chromatic-tuner/chromatic-tuner.js';
         
         document.addEventListener('DOMContentLoaded', function() {
             const component = document.getElementById('demo-component');

--- a/demos/current-chord-demo.html
+++ b/demos/current-chord-demo.html
@@ -131,7 +131,7 @@
     <!-- Component-specific script will be inserted here -->
     
     <script type="module">
-        import './components/current-chord/current-chord.js';
+        import '../components/current-chord/current-chord.js';
         
         document.addEventListener('DOMContentLoaded', function() {
             const component = document.getElementById('demo-component');

--- a/demos/eq-display-demo.html
+++ b/demos/eq-display-demo.html
@@ -131,7 +131,7 @@
     <!-- Component-specific script will be inserted here -->
     
     <script type="module">
-        import './components/eq-display/eq-display.js';
+        import '../components/eq-display/eq-display.js';
         
         document.addEventListener('DOMContentLoaded', function() {
             const component = document.getElementById('demo-component');

--- a/demos/frequency-monitor-demo.html
+++ b/demos/frequency-monitor-demo.html
@@ -131,7 +131,7 @@
     <!-- Component-specific script will be inserted here -->
     
     <script type="module">
-        import './components/frequency-monitor/frequency-monitor.js';
+        import '../components/frequency-monitor/frequency-monitor.js';
         
         document.addEventListener('DOMContentLoaded', function() {
             const component = document.getElementById('demo-component');

--- a/demos/fretboard-demo.html
+++ b/demos/fretboard-demo.html
@@ -172,7 +172,7 @@
     <!-- Component-specific script will be inserted here -->
     
     <script type="module">
-        import './components/fretboard/fretboard.js';
+        import '../components/fretboard/fretboard.js';
         
         document.addEventListener('DOMContentLoaded', function() {
             const component = document.getElementById('demo-component');

--- a/demos/gigso-keyboard-demo.html
+++ b/demos/gigso-keyboard-demo.html
@@ -147,7 +147,7 @@
     <!-- Component-specific script will be inserted here -->
     
     <script type="module">
-        import './components/gigso-keyboard/gigso-keyboard.js';
+        import '../components/gigso-keyboard/gigso-keyboard.js';
         
         document.addEventListener('DOMContentLoaded', function() {
             const component = document.getElementById('demo-component');

--- a/demos/gigso-logo-demo.html
+++ b/demos/gigso-logo-demo.html
@@ -131,7 +131,7 @@
     <!-- Component-specific script will be inserted here -->
     
     <script type="module">
-        import './components/gigso-logo/gigso-logo.js';
+        import '../components/gigso-logo/gigso-logo.js';
         
         document.addEventListener('DOMContentLoaded', function() {
             const component = document.getElementById('demo-component');

--- a/demos/gigso-menu-demo.html
+++ b/demos/gigso-menu-demo.html
@@ -131,7 +131,7 @@
     <!-- Component-specific script will be inserted here -->
     
     <script type="module">
-        import './components/gigso-menu/gigso-menu.js';
+        import '../components/gigso-menu/gigso-menu.js';
         
         document.addEventListener('DOMContentLoaded', function() {
             const component = document.getElementById('demo-component');

--- a/demos/hand-pan-demo.html
+++ b/demos/hand-pan-demo.html
@@ -158,7 +158,7 @@
     <!-- Component-specific script will be inserted here -->
     
     <script type="module">
-        import './components/hand-pan/hand-pan.js';
+        import '../components/hand-pan/hand-pan.js';
         
         document.addEventListener('DOMContentLoaded', function() {
             const component = document.getElementById('demo-component');

--- a/demos/hand-pan-wrapper-demo.html
+++ b/demos/hand-pan-wrapper-demo.html
@@ -131,7 +131,7 @@
     <!-- Component-specific script will be inserted here -->
     
     <script type="module">
-        import './components/hand-pan-wrapper/hand-pan-wrapper.js';
+        import '../components/hand-pan-wrapper/hand-pan-wrapper.js';
         
         document.addEventListener('DOMContentLoaded', function() {
             const component = document.getElementById('demo-component');

--- a/demos/loop-button-demo.html
+++ b/demos/loop-button-demo.html
@@ -131,7 +131,7 @@
     <!-- Component-specific script will be inserted here -->
     
     <script type="module">
-        import './components/loop-button/loop-button.js';
+        import '../components/loop-button/loop-button.js';
         
         document.addEventListener('DOMContentLoaded', function() {
             const component = document.getElementById('demo-component');

--- a/demos/piano-roll-demo.html
+++ b/demos/piano-roll-demo.html
@@ -144,7 +144,7 @@
     <!-- Component-specific script will be inserted here -->
     
     <script type="module">
-        import './components/piano-roll/piano-roll.js';
+        import '../components/piano-roll/piano-roll.js';
         
         document.addEventListener('DOMContentLoaded', function() {
             const component = document.getElementById('demo-component');

--- a/demos/play-button-demo.html
+++ b/demos/play-button-demo.html
@@ -131,7 +131,7 @@
     <!-- Component-specific script will be inserted here -->
     
     <script type="module">
-        import './components/play-button/play-button.js';
+        import '../components/play-button/play-button.js';
         
         document.addEventListener('DOMContentLoaded', function() {
             const component = document.getElementById('demo-component');

--- a/demos/record-collection-demo.html
+++ b/demos/record-collection-demo.html
@@ -131,7 +131,7 @@
     <!-- Component-specific script will be inserted here -->
     
     <script type="module">
-        import './components/record-collection/record-collection.js';
+        import '../components/record-collection/record-collection.js';
         
         document.addEventListener('DOMContentLoaded', function() {
             const component = document.getElementById('demo-component');

--- a/demos/scale-key-demo.html
+++ b/demos/scale-key-demo.html
@@ -131,7 +131,7 @@
     <!-- Component-specific script will be inserted here -->
     
     <script type="module">
-        import './components/scale-key/scale-key.js';
+        import '../components/scale-key/scale-key.js';
         
         document.addEventListener('DOMContentLoaded', function() {
             const component = document.getElementById('demo-component');

--- a/demos/stop-button-demo.html
+++ b/demos/stop-button-demo.html
@@ -131,7 +131,7 @@
     <!-- Component-specific script will be inserted here -->
     
     <script type="module">
-        import './components/stop-button/stop-button.js';
+        import '../components/stop-button/stop-button.js';
         
         document.addEventListener('DOMContentLoaded', function() {
             const component = document.getElementById('demo-component');

--- a/demos/transport-controls-demo.html
+++ b/demos/transport-controls-demo.html
@@ -142,7 +142,7 @@
     <!-- Component-specific script will be inserted here -->
     
     <script type="module">
-        import './components/transport-controls/transport-controls.js';
+        import '../components/transport-controls/transport-controls.js';
         
         document.addEventListener('DOMContentLoaded', function() {
             const component = document.getElementById('demo-component');

--- a/demos/vu-meter-demo.html
+++ b/demos/vu-meter-demo.html
@@ -131,7 +131,7 @@
     <!-- Component-specific script will be inserted here -->
     
     <script type="module">
-        import './components/vu-meter/vu-meter.js';
+        import '../components/vu-meter/vu-meter.js';
         
         document.addEventListener('DOMContentLoaded', function() {
             const component = document.getElementById('demo-component');


### PR DESCRIPTION
Fix `/demos/` pages to load correctly by updating redirects, correcting JS import paths, and adding necessary headers.

The original issue stemmed from a malformed `_redirects` rule that caused `/demos/` to serve the homepage, and demo HTML files incorrectly referenced JavaScript components with `./components/` instead of `../components/`, breaking functionality. This PR addresses both by ensuring direct serving of demo files and correcting all component import paths.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-c0e684d2-ce20-4214-9f17-1d003d590808) · [Cursor](https://cursor.com/background-agent?bcId=bc-c0e684d2-ce20-4214-9f17-1d003d590808)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)